### PR TITLE
bump node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
 env:
   "GITHUB_TOKEN": "As provided by Github Actions"
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   color: "blue"


### PR DESCRIPTION
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/